### PR TITLE
Merged output file generation

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -20,4 +20,15 @@ robot template --template linking.tsv --output linking.owl
 
 #robot merge -i linking.owl -i publication.owl -o merged.owl
 
-cp linking.owl "$(basename linking.owl .owl)_$(date +'%Y%m%d%H%M').owl"
+#cp linking.owl "$(basename linking.owl .owl)_$(date +'%Y%m%d%H%M').owl"
+
+FILE=merged.owl
+if [ -f "$FILE" ]; then
+    robot merge -i merged.owl -i linking.owl -o merged.owl
+else
+    robot merge -i linking.owl -o merged.owl
+fi
+
+echo "Process completed!"
+echo "VFBTIME:"
+date


### PR DESCRIPTION
In the current execution, a time stamped linking_%Y%m%d%H%M.owl file is generated at the end of every crawling.

Due to frequent crawling, lots of these files are generated and making the data collection slower.

With this PR, individual linking result (linking.owl) will be merged to a single file (merged.owl) at the end of each crawling. By this way VFB collect can quickly ingest a single file (merged.owl), instead of several linking_date.owl files.