### PR TITLE
OPENBLAS server exception fix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,6 @@
 import os
+os.environ['OPENBLAS_NUM_THREADS'] = '1'
+
 from decimal import Decimal
 from file_utils import read_csv_to_dict, write_mentions_to_file, clean_folder, read_txt_file
 from nlp_utils import count_keywords
@@ -16,7 +18,6 @@ from scispacy.candidate_generation import (
     CandidateGenerator,
     LinkerPaths
 )
-
 
 CONFIDENCE_THRESHOLD = 0.85
 # apply a relative threshold based on the highest confidence per mention


### PR DESCRIPTION
Bugfix for server exception: 
```log
30/06/2023 09:39:35OpenBLAS blas_thread_init: pthread_create failed for thread 1 of 46: Operation not permitted
30/06/2023 09:39:35OpenBLAS blas_thread_init: RLIMIT_NPROC 983501 current, 983501 max
so set OPENBLAS_NUM_THREADS=1
```
https://stackoverflow.com/questions/52026652/openblas-blas-thread-init-pthread-create-resource-temporarily-unavailable